### PR TITLE
fix: default to empty list for `get_all_children`

### DIFF
--- a/trans_ms/transport_management/doctype/requested_payments/requested_payments.py
+++ b/trans_ms/transport_management/doctype/requested_payments/requested_payments.py
@@ -25,7 +25,7 @@ class RequestedPayments(Document):
 
     def get_all_children(self, parenttype=None):
         # For getting children
-        return self.get("payments_reference")
+        return self.get("payments_reference") or []
 
     def update_children(self):
         """update child tables"""


### PR DESCRIPTION
since https://github.com/frappe/frappe/pull/16540, `doc.get` does not return an empty list for child tables if the value is `None`, so falling back to an empty list if that is the case.

v14 backport of #16